### PR TITLE
Simplify Flask import and fix scraper imports

### DIFF
--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -14,8 +14,8 @@ from flask import (
 
 from app.domain.scraper_control import get_result, new_job, set_result, stop_job
 from app.infrastructure.scrape_bumeran import scrape_bumeran
-from app.infrastructure.scrape_computrabajo import scrape_computrabajo
-from app.infrastructure.scrape_zonajobs import scrape_zonajobs
+from app.infrastructure.computrabajo import scrape_computrabajo
+from app.infrastructure.zonajobs import scrape_zonajobs
 
 from .worker import _excel_response, _json_response, _worker_scrape
 

--- a/run_app.py
+++ b/run_app.py
@@ -1,4 +1,4 @@
-from flask import Flask, abort, current_app, jsonify, request, send_file, render_template
+from flask import Flask
 from app.web import create_app
 
 app = create_app()


### PR DESCRIPTION
## Summary
- simplify Flask import in run_app
- fix module paths for scraper imports so the app can run

## Testing
- `python run_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68966c6dc35c8327a6ef570180576576