### PR TITLE
Fix Bumeran scraper import in routes

### DIFF
--- a/app/infrastructure/routes.py
+++ b/app/infrastructure/routes.py
@@ -13,7 +13,7 @@ from flask import (
 )
 
 from app.domain.scraper_control import get_result, new_job, set_result, stop_job
-from app.infrastructure.bumeran.scraper import scrape_bumeran
+from app.infrastructure.bumeran import scrap_jobs_bumeran
 from app.infrastructure.computrabajo import scrape_computrabajo
 from app.infrastructure.zonajobs import scrape_zonajobs
 
@@ -22,7 +22,7 @@ from .worker import _excel_response, _json_response, _worker_scrape
 bp = Blueprint("web", __name__)
 
 SCRAPERS: dict[str, Callable[..., list[dict[str, Any]]]] = {
-    "bumeran": scrape_bumeran,
+    "bumeran": scrap_jobs_bumeran,
     "zonajobs": scrape_zonajobs,
     "computrabajo": scrape_computrabajo,
 }


### PR DESCRIPTION
## Summary
- fix Bumeran scraper import to use existing `scrap_jobs_bumeran`
- point SCRAPERS mapping to the corrected scraper function

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689681c8d6ec832798d45549b624c444