### PR TITLE
refactor: reuse worker helpers in script

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
-import io
-import json
+
 import threading
-from pathlib import Path
 from typing import Any, Callable
-from flask import Flask, abort, current_app, jsonify, request, send_file,render_template
+
+from flask import Flask, abort, jsonify, request, render_template
 from flask_cors import CORS
-import pandas as pd
 from dotenv import load_dotenv
 
 # Módulos propios
-from app.domain.scraper_control import ask_to_stop, get_result, new_job, set_result, stop_job
+from app.domain.scraper_control import get_result, new_job, set_result, stop_job
 from app.infrastructure.bumeran import scrap_jobs_bumeran
 from app.infrastructure.computrabajo import scrape_computrabajo
 from app.infrastructure.zonajobs import scrape_zonajobs
+from app.infrastructure.worker import _excel_response, _json_response, _worker_scrape
 
 load_dotenv()
 app = Flask(__name__)
@@ -54,41 +53,6 @@ def start_scrape():
 
     return jsonify(job_id=job_id, fmt=fmt, portal=portal)
 
-def _worker_scrape(
-    portal: str, data: dict, job_id: str, func: Callable, set_result: Callable, app: Flask
-):
-    kwargs: dict[str, Any] = {"job_id": job_id}
-    cargo = data.get("cargo", "").strip()
-    ubic  = data.get("ubicacion", "").strip()
-
-    # Cargar parámetros base según el portal
-    if portal == "computrabajo":
-        kwargs["categoria"] = cargo
-        kwargs["lugar"] = ubic
-    elif portal in ("bumeran", "zonajobs", "mpar"):
-        if cargo:
-            kwargs["query"] = cargo
-        if ubic:
-            kwargs["location"] = ubic
-
-    # Permitir límite de páginas si lo pasan desde el front
-    max_pages = data.get("pages") or data.get("max_pages")
-    if max_pages:
-        try:
-            kwargs["max_pages"] = int(max_pages)
-        except Exception:
-            app.logger.warning("Parametro de páginas inválido: %s", max_pages)
-
-    app.logger.debug("Scraper %s – kwargs: %s", portal, kwargs)
-
-    # Ejecución y manejo de errores
-    try:
-        res = func(**kwargs)
-    except Exception as exc:
-        app.logger.exception("Scraper %s falló: %s", portal, exc)
-        res = []
-    set_result(job_id, res)
-
 @app.post("/stop-scrape")
 def stop_scrape():
     payload = request.get_json(silent=True) or {}
@@ -119,36 +83,6 @@ def download(job_id):
     fmt = request.args.get("fmt", "json").lower()
     filename = f"{job_id}.{ 'xlsx' if fmt == 'excel' else 'json' }"
     return _excel_response(data, filename) if fmt == "excel" else _json_response(data, filename)
-
-# Helpers de respuesta
-def _json_response(payload: list[dict[str, Any]], filename: str):
-    buf = io.BytesIO(json.dumps(payload, ensure_ascii=False, indent=2).encode())
-    buf.seek(0)
-    return send_file(buf, as_attachment=True, mimetype="application/json", download_name=filename)
-
-MIME_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-
-def _excel_response(payload: list[dict[str, Any]], filename: str):
-    df = pd.DataFrame(payload or [])
-    buf = io.BytesIO()
-    for engine in ("xlsxwriter", "openpyxl"):
-        try:
-            with pd.ExcelWriter(buf, engine=engine) as writer:
-                df.to_excel(writer, index=False, sheet_name="vacantes")
-            break
-        except ImportError as exc:
-            current_app.logger.warning("Excel engine '%s' no disponible: %s", engine, exc)
-            buf.seek(0)
-            buf.truncate(0)
-    else:
-        raise RuntimeError(
-            "Para generar Excel instalá:\n"
-            "    pip install XlsxWriter   # o\n"
-            "    pip install openpyxl"
-        )
-
-    buf.seek(0)
-    return send_file(buf, as_attachment=True, mimetype=MIME_XLSX, download_name=filename)
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- import worker helpers for scrape and responses in `run_app.py`
- keep only one implementation shared across routes and script

## Testing
- `python -m py_compile run_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896825746f88327a7964917618e45a9