### PR TITLE
Add headless flag for Computrabajo and Zonajobs scrapers

### DIFF
--- a/app/infrastructure/computrabajo/__init__.py
+++ b/app/infrastructure/computrabajo/__init__.py
@@ -6,10 +6,17 @@ from .scraper import ComputrabajoScraper
 
 
 def scrape_computrabajo(
-    *, categoria: str, lugar: str, job_id: Optional[str] = None, max_pages: Optional[int] = None
+    *,
+    categoria: str,
+    lugar: str,
+    job_id: Optional[str] = None,
+    max_pages: Optional[int] = None,
+    headless: bool = True,
 ) -> List[Dict[str, Any]]:
     with sync_playwright() as pw:
-        browser = pw.chromium.launch(channel="chrome", headless=False, args=["--start-maximized"])
+        browser = pw.chromium.launch(
+            channel="chrome", headless=headless, args=["--start-maximized"]
+        )
         try:
             scraper = ComputrabajoScraper(browser, categoria, lugar, max_pages, job_id)
             return scraper.run()

--- a/app/infrastructure/computrabajo/cli.py
+++ b/app/infrastructure/computrabajo/cli.py
@@ -11,12 +11,14 @@ def main() -> None:
     parser.add_argument("--categoria", required=True)
     parser.add_argument("--lugar", required=True)
     parser.add_argument("--pages", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=True)
     args = parser.parse_args()
 
     resultados = scrape_computrabajo(
         categoria=args.categoria,
         lugar=args.lugar,
         max_pages=args.pages,
+        headless=args.headless,
     )
 
     if resultados:

--- a/app/infrastructure/worker.py
+++ b/app/infrastructure/worker.py
@@ -39,6 +39,13 @@ def _worker_scrape(
         except Exception:
             app.logger.warning("Parametro de páginas inválido: %s", max_pages)
 
+    headless = data.get("headless")
+    if headless is not None:
+        if isinstance(headless, str):
+            kwargs["headless"] = headless.lower() in ("1", "true", "yes", "y")
+        else:
+            kwargs["headless"] = bool(headless)
+
     app.logger.debug("Scraper %s – kwargs: %s", portal, kwargs)
 
     try:

--- a/app/infrastructure/zonajobs/__init__.py
+++ b/app/infrastructure/zonajobs/__init__.py
@@ -12,6 +12,7 @@ def scrape_zonajobs(
     query: str = "",
     location: str = "",
     max_pages: Optional[int] = None,
+    headless: bool = True,
     **_
 ) -> List[Dict[str, Any]]:
     env_pages = os.getenv("ZJ_PAGES")
@@ -21,7 +22,9 @@ def scrape_zonajobs(
         else int(env_pages) if env_pages and env_pages.isdigit() else None
     )
     with sync_playwright() as pw:
-        browser = pw.chromium.launch(headless=False, args=["--window-size=1920,1080"], slow_mo=150)
+        browser = pw.chromium.launch(
+            headless=headless, args=["--window-size=1920,1080"], slow_mo=150
+        )
         try:
             return ZonaJobsScraper(
                 browser=browser,

--- a/app/infrastructure/zonajobs/cli.py
+++ b/app/infrastructure/zonajobs/cli.py
@@ -11,12 +11,14 @@ def main() -> None:
     parser.add_argument("--query", default="")
     parser.add_argument("--location", default="")
     parser.add_argument("--pages", type=int, default=None)
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=True)
     args = parser.parse_args()
 
     resultados = scrape_zonajobs(
         query=args.query,
         location=args.location,
         max_pages=args.pages,
+        headless=args.headless,
     )
 
     if resultados:

--- a/run_app.py
+++ b/run_app.py
@@ -79,6 +79,13 @@ def _worker_scrape(
         except Exception:
             app.logger.warning("Parametro de páginas inválido: %s", max_pages)
 
+    headless = data.get("headless")
+    if headless is not None:
+        if isinstance(headless, str):
+            kwargs["headless"] = headless.lower() in ("1", "true", "yes", "y")
+        else:
+            kwargs["headless"] = bool(headless)
+
     app.logger.debug("Scraper %s – kwargs: %s", portal, kwargs)
 
     # Ejecución y manejo de errores


### PR DESCRIPTION
## Summary
- allow Computrabajo and Zonajobs scrapers to run in headless or headed mode
- propagate headless flag through CLI and API worker functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689682b3aad883279d29112b4a813e6a