### PR TITLE
Use attribute-based selectors for Bumeran listings

### DIFF
--- a/app/infrastructure/bumeran/scraper.py
+++ b/app/infrastructure/bumeran/scraper.py
@@ -16,7 +16,8 @@ except ImportError:
 BASE_URL = "https://www.bumeran.com.ar/"
 BUM_USER = os.getenv("BUMERAN_USER", "")
 BUM_PASS = os.getenv("BUMERAN_PASS", "")
-LISTING_SELECTOR = "#listado-avisos a.sc-gVZiCL"
+# Selector de avisos basado en atributos más estables
+LISTING_SELECTOR = "#listado-avisos a[href*='/empleos-']"
 DETAIL_CONTAINER = "#section-detalle"
 TIMEOUT = 15_000
 ZERO_JOBS_SEL = "span.sc-SxrYz.cBtoeQ:has-text('0')"
@@ -156,6 +157,7 @@ class BumeranScraper:
             get_logger().debug("0 resultados, abortando búsqueda.")
             return
 
+        # Espera a que se carguen los avisos utilizando el nuevo selector estable
         p.wait_for_selector(LISTING_SELECTOR, timeout=TIMEOUT)
         self.filtered_base_url = p.url
 
@@ -163,8 +165,10 @@ class BumeranScraper:
 
     def _get_listing_hrefs(self) -> List[str]:
         p = self.list_page
+        # Utiliza el selector basado en atributos para obtener los enlaces de los avisos
         p.wait_for_selector(LISTING_SELECTOR, timeout=TIMEOUT)
-        urls = p.locator(LISTING_SELECTOR).evaluate_all(
+        listing_links = p.locator(LISTING_SELECTOR)
+        urls = listing_links.evaluate_all(
             "els => Array.from(new Set(els.map(e => e.href)))"
         )  # type: ignore
         return sorted(u for u in urls if u.endswith(".html"))


### PR DESCRIPTION
## Summary
- switch Bumeran listing selector to a stable attribute-based form
- adjust search and link extraction helpers to rely on the new selector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689693e40e988327b15d71933bea81b9