### PR TITLE
feat: improve search load handling

### DIFF
--- a/app/infrastructure/bumeran/scraper.py
+++ b/app/infrastructure/bumeran/scraper.py
@@ -147,7 +147,12 @@ class BumeranScraper:
         boton_buscar.scroll_into_view_if_needed()
         p.wait_for_timeout(2000)
         boton_buscar.click(force=True)
-        p.wait_for_timeout(600)
+        try:
+            p.wait_for_load_state("networkidle", timeout=TIMEOUT * 2)
+        except PWTimeoutError:
+            get_logger().warning(
+                "La carga excedió el plazo de %s ms tras buscar", TIMEOUT * 2
+            )
 
 
         # 4. Espera resultados

--- a/app/infrastructure/zonajobs/scraper.py
+++ b/app/infrastructure/zonajobs/scraper.py
@@ -138,8 +138,12 @@ class ZonaJobsScraper:
             p.keyboard.press("Enter")
         elif self.query:
             p.click("#buscarTrabajo")
-            p.wait_for_timeout(400)
-        p.wait_for_timeout(2000)
+        try:
+            p.wait_for_load_state("networkidle", timeout=TIMEOUT * 2)
+        except TimeoutError:
+            get_logger().warning(
+                "La carga excedió el plazo de %s ms tras buscar", TIMEOUT * 2
+            )
         p.wait_for_selector("#listado-avisos", timeout=TIMEOUT)
         avisos = p.locator(LISTING_SELECTOR)
         n_avisos = avisos.count()


### PR DESCRIPTION
## Summary
- wait for network idle instead of fixed timeout after search in Bumeran scraper
- wait for network idle instead of fixed timeout after search in ZonaJobs scraper

## Testing
- `pytest`
- `python -m py_compile app/infrastructure/bumeran/scraper.py app/infrastructure/zonajobs/scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_689693e6f71c83278f9eef689ebe4250