### PR TITLE
Add configurable timeout to Bumeran scraper

### DIFF
--- a/app/infrastructure/bumeran/__init__.py
+++ b/app/infrastructure/bumeran/__init__.py
@@ -12,12 +12,18 @@ def scrap_jobs_bumeran(
     max_pages: Optional[int] = None,
     job_id: Optional[str] = None,
     headless: bool = True,
+    timeout: int = 15_000,
 ) -> List[Dict[str, Any]]:
     with sync_playwright() as pw:
         browser = pw.chromium.launch(headless=headless, args=["--start-maximized"])
         try:
             scraper = BumeranScraper(
-                browser, query=query, location=location, max_pages=max_pages, job_id=job_id
+                browser,
+                query=query,
+                location=location,
+                max_pages=max_pages,
+                job_id=job_id,
+                timeout=timeout,
             )
             return scraper.run()
         finally:

--- a/app/infrastructure/bumeran/scraper.py
+++ b/app/infrastructure/bumeran/scraper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import os
 import urllib.parse as ul
 from typing import Any, Dict, List
-from playwright.sync_api import Browser, Page, sync_playwright, TimeoutError as PWTimeoutError
+from playwright.sync_api import Browser, Page, TimeoutError as PWTimeoutError
 from app.infrastructure.utils import parse_fecha_publicacion
 
 from app.logging_utils import get_logger
@@ -18,7 +18,6 @@ BUM_USER = os.getenv("BUMERAN_USER", "")
 BUM_PASS = os.getenv("BUMERAN_PASS", "")
 LISTING_SELECTOR = "#listado-avisos a.sc-gVZiCL"
 DETAIL_CONTAINER = "#section-detalle"
-TIMEOUT = 15_000
 ZERO_JOBS_SEL = "span.sc-SxrYz.cBtoeQ:has-text('0')"
 NEXT_BTN = "a.sc-dzVpKk.hFOZsP"
 
@@ -30,12 +29,14 @@ class BumeranScraper:
         location: str = "",
         max_pages: int | None = None,
         job_id: str | None = None,
+        timeout: int = 15_000,
     ) -> None:
         self.browser = browser
         self.query = query.strip()
         self.location = location.strip()
         self.max_pages = max_pages
         self.job_id = job_id or ""
+        self.timeout = timeout
         self.context = browser.new_context(viewport=None)
         self.list_page: Page = self.context.new_page()
         self.detail_page: Page = self.context.new_page()
@@ -72,16 +73,16 @@ class BumeranScraper:
 
     def _login_and_search(self) -> None:
         p = self.list_page
-        p.goto(BASE_URL, timeout=TIMEOUT)
-        p.wait_for_selector("a[href*='/postulantes']", timeout=TIMEOUT)
+        p.goto(BASE_URL, timeout=self.timeout)
+        p.wait_for_selector("a[href*='/postulantes']", timeout=self.timeout)
 
         if self.query or self.location:
-            #p.goto(BASE_URL, timeout=TIMEOUT)
+            #p.goto(BASE_URL, timeout=self.timeout)
             self._buscar_con_inputs()
         else:
             self.filtered_base_url = f"{BASE_URL}empleos.html?recientes=true"
-            p.goto(f"{self.filtered_base_url}&page=1", timeout=TIMEOUT)
-            p.wait_for_selector(LISTING_SELECTOR, timeout=TIMEOUT)
+            p.goto(f"{self.filtered_base_url}&page=1", timeout=self.timeout)
+            p.wait_for_selector(LISTING_SELECTOR, timeout=self.timeout)
 
 
     def _buscar_con_inputs(self) -> None:
@@ -90,7 +91,7 @@ class BumeranScraper:
         # 1. Click placeholder de puesto PARA DESPERTAR EL INPUT
         if self.query:
             get_logger().debug("Click placeholder puesto")
-            p.wait_for_selector("div.select__placeholder:has-text('Buscar empleo por puesto o palabra clave')", timeout=TIMEOUT)
+            p.wait_for_selector("div.select__placeholder:has-text('Buscar empleo por puesto o palabra clave')", timeout=self.timeout)
             ph_puesto = p.locator("div.select__placeholder:has-text('Buscar empleo por puesto o palabra clave')").first
             # Simula doble click para forzar apertura de input
             ph_puesto.click(force=True)
@@ -120,7 +121,7 @@ class BumeranScraper:
         # 2. Click placeholder de ubicación PARA DESPERTAR EL INPUT
         if self.location:
             get_logger().debug("Click placeholder ubicación")
-            p.wait_for_selector("div.select__placeholder:has-text('Lugar de trabajo')", timeout=TIMEOUT)
+            p.wait_for_selector("div.select__placeholder:has-text('Lugar de trabajo')", timeout=self.timeout)
             ph_ubic = p.locator("div.select__placeholder:has-text('Lugar de trabajo')").first
             ph_ubic.click(force=True)
             p.wait_for_timeout(120)
@@ -156,14 +157,14 @@ class BumeranScraper:
             get_logger().debug("0 resultados, abortando búsqueda.")
             return
 
-        p.wait_for_selector(LISTING_SELECTOR, timeout=TIMEOUT)
+        p.wait_for_selector(LISTING_SELECTOR, timeout=self.timeout)
         self.filtered_base_url = p.url
 
 
 
     def _get_listing_hrefs(self) -> List[str]:
         p = self.list_page
-        p.wait_for_selector(LISTING_SELECTOR, timeout=TIMEOUT)
+        p.wait_for_selector(LISTING_SELECTOR, timeout=self.timeout)
         urls = p.locator(LISTING_SELECTOR).evaluate_all(
             "els => Array.from(new Set(els.map(e => e.href)))"
         )  # type: ignore
@@ -171,8 +172,8 @@ class BumeranScraper:
 
     def _scrape_detail(self, url: str) -> Dict[str, Any]:
         dp = self.detail_page
-        dp.goto(url, timeout=TIMEOUT)
-        dp.wait_for_selector(DETAIL_CONTAINER, timeout=TIMEOUT)
+        dp.goto(url, timeout=self.timeout)
+        dp.wait_for_selector(DETAIL_CONTAINER, timeout=self.timeout)
 
         data: Dict[str, Any] = {"url": url}
 
@@ -232,8 +233,8 @@ class BumeranScraper:
                 next_btn.click()
             else:
                 url = f"{BASE_URL}empleos.html?recientes=true&palabra={ul.quote_plus(self.query)}&page={num}"
-                p.goto(url, timeout=TIMEOUT)
-            p.wait_for_selector(LISTING_SELECTOR, timeout=TIMEOUT)
+                p.goto(url, timeout=self.timeout)
+            p.wait_for_selector(LISTING_SELECTOR, timeout=self.timeout)
             return True
         except PWTimeoutError:
             return False

--- a/run_app.py
+++ b/run_app.py
@@ -95,6 +95,15 @@ def _worker_scrape(
                     "Parametro de páginas inválido: %s", max_pages
                 )
 
+        timeout = data.get("timeout")
+        if timeout and portal == "bumeran":
+            try:
+                kwargs["timeout"] = int(timeout)
+            except Exception:
+                current_app.logger.warning(
+                    "Parametro de timeout inválido: %s", timeout
+                )
+
         current_app.logger.debug("Scraper %s – kwargs: %s", portal, kwargs)
 
         # Ejecución y manejo de errores


### PR DESCRIPTION
## Summary
- allow setting timeout in `BumeranScraper` and use it for Playwright calls
- pass timeout through `scrap_jobs_bumeran`
- forward `timeout` parameter from `run_app`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689693e743448327a96ee68ba54323e3