### PR TITLE
Add configurable export paths to Zonajobs CLI

### DIFF
--- a/app/infrastructure/zonajobs/cli.py
+++ b/app/infrastructure/zonajobs/cli.py
@@ -8,11 +8,18 @@ from . import scrape_zonajobs
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Scrapea Zonajobs")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scrapea Zonajobs. "
+            "Utiliza --json-path y --excel-path para especificar las rutas de exportación."
+        )
+    )
     parser.add_argument("--query", default="")
     parser.add_argument("--location", default="")
     parser.add_argument("--pages", type=int, default=None)
     parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--json-path", default="zonajobs.json")
+    parser.add_argument("--excel-path", default="zonajobs.xlsx")
     args = parser.parse_args()
 
     resultados = scrape_zonajobs(
@@ -23,11 +30,15 @@ def main() -> None:
     )
 
     if resultados:
-        df = pd.DataFrame(resultados)
-        df.to_excel("zonajobs.xlsx", index=False)
-        with open("zonajobs.json", "w", encoding="utf-8") as f:
-            json.dump(resultados, f, ensure_ascii=False, indent=2)
-        get_logger().info("%s registros exportados.", len(resultados))
+        try:
+            df = pd.DataFrame(resultados)
+            df.to_excel(args.excel_path, index=False)
+            with open(args.json_path, "w", encoding="utf-8") as f:
+                json.dump(resultados, f, ensure_ascii=False, indent=2)
+        except Exception as exc:
+            get_logger().error("Error al exportar los datos: %s", exc)
+        else:
+            get_logger().info("%s registros exportados.", len(resultados))
     else:
         get_logger().info("No se extrajeron datos.")
 


### PR DESCRIPTION
## Summary
- allow specifying JSON and Excel output paths in Zonajobs CLI
- log export errors and provide guidance in parser description

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e5d1ef988327a4ff4328c17b4be4