### PR TITLE
chore: remove unused json import

### DIFF
--- a/app/infrastructure/zonajobs/scraper.py
+++ b/app/infrastructure/zonajobs/scraper.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import re
-import json
 import time
 import unicodedata
 import urllib.parse as ul


### PR DESCRIPTION
## Summary
- remove unused json import from ZonaJobs scraper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e5d482208327a8d2c8c5ad19ebb3